### PR TITLE
Distributions such as 'mconf-trusty' and 'trusty' have their own attr…

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -8,6 +8,7 @@
 
 default['bbb']['bigbluebutton']['repo_url'] = "http://ubuntu.bigbluebutton.org/trusty-090"
 default['bbb']['bigbluebutton']['key_url'] = "http://ubuntu.bigbluebutton.org/bigbluebutton.asc"
+default['bbb']['bigbluebutton']['dist'] = "trusty"
 default['bbb']['bigbluebutton']['components'] = ["bigbluebutton-trusty" , "main"]
 default['bbb']['bigbluebutton']['package_name'] = "bigbluebutton"
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -34,7 +34,8 @@ include_recipe "ffmpeg"
 # add ubuntu repo
 apt_repository "ubuntu" do
   uri "http://archive.ubuntu.com/ubuntu/"
-  components ["trusty" , "multiverse"]
+  distribution "trusty"
+  components ["multiverse"]
 end
 
 package "software-properties-common"
@@ -59,6 +60,7 @@ package "wget"
 apt_repository node['bbb']['bigbluebutton']['package_name'] do
   key node['bbb']['bigbluebutton']['key_url']
   uri node['bbb']['bigbluebutton']['repo_url']
+  distribution node['bbb']['bigbluebutton']['dist']
   components node['bbb']['bigbluebutton']['components']
   notifies :run, 'execute[apt-get update]', :immediately
 end


### PR DESCRIPTION
"_trusty_" and "_mconf-trusty_" are not part of components specification of the repository. They are distributions. Somehow keeping it as part of components worked on Chef 11.18.6 (I'm not sure until which version it worked), but it creates a wrong repository entry on Chef 12.11.18 (both with `apt` 2.7.0).

Resource `apt_repository` provides an attribute for distributions such as "_trusty_" and "_mconf_trusty_". Apparently this attribute defaults to "_trusty_". Note that now there is a new attribute `node['bbb']['bigbluebutton']['dist']` which should have the value "_mconf-trusty_". 
